### PR TITLE
Fix ProcessTest.testWaitFor()

### DIFF
--- a/src/malva/java/lang/ProcessTest.java
+++ b/src/malva/java/lang/ProcessTest.java
@@ -80,26 +80,28 @@ public class ProcessTest extends TestCase {
   }
 
   public static void testWaitFor() {
-    Thread testerThread = new Thread(new Runnable() {
-      @Override public void run() {
-        ProcessBuilder processBuilder = new ProcessBuilder("env");
-        try {
-          final Process process = processBuilder.start();
-          // Read all output after which the process will complete
-          while (process.getInputStream().read() != -1);
-          process.waitFor();
-        } catch (Exception e) {
-          fail("Test failed: "  + e.getMessage());
-        }
-      }
-    });
-
-    testerThread.start();
-
     try {
+      final Process process = Runtime.getRuntime().exec("env");
+      // Read all output after which the process will complete
+      while (process.getInputStream().read() != -1);
+
+      Thread testerThread = new Thread(new Runnable() {
+        @Override public void run() {
+          try {
+            process.waitFor();
+          } catch (InterruptedException e) {
+            // ignored
+          }
+        }
+      });
+
+      testerThread.start();
       testerThread.join(100);
-    } catch (InterruptedException e) {
-      fail("Test failed as test did not complete in time: " + e.getMessage());
+      // Check that the thread exited, and that the process finished successfully
+      assertFalse(testerThread.isAlive());
+      assertEquals(0, process.exitValue());
+    } catch (Exception e) {
+      fail("Test failed: "  + e);
     }
   }
 


### PR DESCRIPTION
- Calls to fail() in a thread other than the main one have no effect. fail() throws an AssertionError that kills the calling thread, but is not seen by the main thread and does not make the test fail.
- The test incorrectly assumes that Thread.join() will throw an InterruptedException if the joined thread does not finish within the specified timeout. This is not the case.

Fix this by checking that the thread actually exited after join() returns, and that the process finished successfully.