### PR TITLE
New URLConnection test for exception thrown on connect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ CLASSES += src/malva/java/lang/reflect/FieldTest.class
 CLASSES += src/malva/java/math/BigDecimalTest.class
 CLASSES += src/malva/java/net/InetAddressTest.class
 CLASSES += src/malva/java/net/NetworkInterfaceTest.class
+CLASSES += src/malva/java/net/URLConnectionTest.class
 CLASSES += src/malva/java/nio/DirectByteBufferTest.class
 CLASSES += src/malva/java/text/DecimalFormatTest.class
 CLASSES += src/malva/java/text/SimpleDateFormatTest.class

--- a/src/malva/java/net/URLConnectionTest.java
+++ b/src/malva/java/net/URLConnectionTest.java
@@ -1,0 +1,26 @@
+package malva.java.net;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+
+import malva.TestCase;
+
+public class URLConnectionTest extends TestCase {
+  private static void testConnect() throws Exception {
+    // Connect with unresolvable hostname
+    URL url = new URL("http", "anunresolvablehost", 80, "index.html");
+    final URLConnection connection = url.openConnection();
+    connection.setUseCaches(false);
+    assertThrows(new Block() {
+      @Override
+      public void run() throws Throwable {
+        connection.connect();
+      }
+    }, IOException.class);
+  }
+
+  public static void main(String[] args) throws Exception {
+    testConnect();
+  }
+}


### PR DESCRIPTION
When the remote end address was not resolved an `IOException` should be thrown.